### PR TITLE
fix show page for the racer with zero races

### DIFF
--- a/app/views/racers/show.html.erb
+++ b/app/views/racers/show.html.erb
@@ -22,7 +22,9 @@
       <% end %>
       <% if @has_results %>
       <h4>Races: <%= @racer.race_count %></h4>
+      <% if @racer.results.exists? %>
       <h4>PR: <%= @racer.results.order(:time).first.time%></h4>
+      <% end %>
       <h4>Loop-Beer Runs: <%= @racer.results.where("group_name = ?", "Loop-Beer").count %></h4>
       <% end %>
       <%= @users_race_count %>

--- a/test/controllers/racers_controller_test.rb
+++ b/test/controllers/racers_controller_test.rb
@@ -27,6 +27,12 @@ class RacersControllerTest < ActionController::TestCase
     end
   end
 
+  test "racer show displays basic racer info for racer with zero races" do
+    get :show, id: racers(:two).id
+    assert_select "h2", racers(:two).first_name + " " + racers(:two).last_name
+    assert_select "h4:first-of-type", "Races: 0"
+  end
+
   test "racer show displays correct streak info" do
     racer = Racer.new(first_name: "Tommy", last_name: "Streak", race_count: 0, longest_streak: 0, current_streak: 0, fav_bib: 0)
     racer.save


### PR DESCRIPTION
Hi Max, it was a good run today. Thank you.
I've just fixed the problem that I mentioned to you.
You can find scenario(use case) below:

Scenario:
You are the racer with zero races 
If you go to the show page, you get the error page("something went wrong")
But it works for the racers who have at least one result(previous race)

Fix:
`@racer.results.order(:time).first` will be `nil` if you have zero races. 
So I've just added `if` condition to show that line. 
I checked it on my local machine. Now it works as expected.

See you next time!