### PR TITLE
Recalculate streaks for active racers

### DIFF
--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -110,16 +110,12 @@ class RacesController < ApplicationController
   # Save race
   def save_race
     race = Race.find(params[:id])
+    racer_ids = race.results.pluck(:racer_id)
+    streak_racer_ids = Racer.where("current_streak > 0 OR longest_streak > 0").pluck(:id)
+    racer_ids_to_update = (racer_ids + streak_racer_ids).uniq
 
-    # Update racer info for all racers in this race.
-    for result in race.results do
-      update_racer_info(result.racer)
-    end
-
-    # Update racer info for all racers in the second most recent race.
-    # This is to make sure racer who may be exiting a streak are updated accordingly.
-    Race.order("date DESC").second&.results&.each do |result|
-      update_racer_info(result.racer)
+    Racer.where(id: racer_ids_to_update).find_each do |racer|
+      update_racer_info(racer)
     end
 
     race.update(state: 'FINISHED')


### PR DESCRIPTION
### Motivation
- Streak recalculation was only triggered when an admin used `save_race` and previously only updated racers in the current and second-most-recent race, which can leave stale or incorrect streaks.
- The intent is to ensure streaks and related stats are correct even when `Save Race` isn't used for every race by recalculating for all affected racers.

### Description
- In `save_race` collect `racer_ids` from the saved race and `streak_racer_ids` from `Racer.where("current_streak > 0 OR longest_streak > 0")` and combine them into `racer_ids_to_update`.
- Replace the per-result loops with `Racer.where(id: racer_ids_to_update).find_each` and call `update_racer_info` for each racer.
- Remove the previous special-case logic that only updated the second most recent race to ensure broader, more reliable recalculation.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598e2d1eb483299f876c61cd9060a6)