### PR TITLE
Use recent runs to rank likely racers

### DIFF
--- a/app/controllers/start_items_controller.rb
+++ b/app/controllers/start_items_controller.rb
@@ -100,16 +100,22 @@ class StartItemsController < ApplicationController
   end
 
   # Get a list of likely racers for a race.
-  # Likely racers are the top 12 racers with more than 10 races OR
-  # a current streak of more than 1, excluding those already registered.
+  # Likely racers are those on a current streak or who have been running in
+  # the last three months, excluding those already registered.
   def get_likely_racers(race_id)
     already_registered = StartItem.where(:race_id => race_id).pluck(:racer_id)
-    if already_registered.length > 0
-      likely_racers = Racer.where(["(race_count > ? OR current_streak > ?) AND id not in (?)", 20, 0, already_registered]).order("current_streak DESC, race_count DESC").first(20)
-    else
-      likely_racers = Racer.where(["race_count > ? OR current_streak > ?", 20, 0]).order("current_streak DESC, race_count DESC").first(20)
-    end
-    return likely_racers
+    recent_cutoff = 3.months.ago.to_date
+    recent_race_counts = Result.joins(:race)
+                               .where("races.date >= ?", recent_cutoff)
+                               .group(:racer_id)
+                               .count
+    recent_racer_ids = recent_race_counts.keys
+    scope = Racer.where(["current_streak > ? OR id IN (?)", 0, recent_racer_ids])
+    scope = scope.where.not(id: already_registered) if already_registered.any?
+
+    scope.to_a
+         .sort_by { |racer| [-racer.current_streak, -(recent_race_counts[racer.id] || 0)] }
+         .first(20)
   end
 
   private


### PR DESCRIPTION
### Motivation
- Improve the likely-racer selection so it prioritizes racers who have been active in the last three months and those on a current streak, instead of relying on all-time race counts.
- Ensure racers already registered for the target race are excluded from the recommendations.

### Description
- Rewrote `get_likely_racers` in `app/controllers/start_items_controller.rb` to compute a `recent_cutoff` (`3.months.ago.to_date`) and aggregate recent run counts via `Result.joins(:race).where("races.date >= ?", recent_cutoff).group(:racer_id).count`.
- Build a candidate set of `Racer` records where `current_streak > 0` or the racer appears in the recent activity list, exclude `already_registered` racer IDs, and then sort by `current_streak` and recent run count before returning the top 20.
- Removed the previous all-time `race_count` threshold logic and updated the method comment to reflect the new behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598e3752d48329bec913863bba199a)