### PR TITLE
Add `/__next_race` endpoint to auto-create next Wednesday race

### DIFF
--- a/app/controllers/next_race_controller.rb
+++ b/app/controllers/next_race_controller.rb
@@ -1,0 +1,15 @@
+require "#{Rails.root}/lib/utils"
+
+class NextRaceController < ApplicationController
+  def show
+    race_date = get_next_day_of_week(3)
+    race = Race.find_by(date: race_date)
+
+    if race
+      render json: { status: "exists", date: race_date }, status: :ok
+    else
+      race = Race.create!(date: race_date, state: "PLANNED")
+      render json: { status: "created", date: race.date }, status: :created
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
  
   root 'welcome#index'
   get '/__health' => 'health#show'
+  get '/__next_race' => 'next_race#show'
   get 'welcome/index'
   get '/count' => 'pages#count'
   get '/records' => 'pages#records'


### PR DESCRIPTION
### Motivation
- Provide an HTTP endpoint that mirrors the existing rake task to auto-create the next Wednesday race so it can be triggered remotely.
- Allow automated systems or health checks to ensure the next race exists without running rake tasks manually.

### Description
- Added `app/controllers/next_race_controller.rb` with `NextRaceController#show` that calls `get_next_day_of_week(3)` and either returns the existing race or creates one with `state: "PLANNED"` using `Race.create!`.
- Required `lib/utils` in the controller to reuse `get_next_day_of_week` logic.
- Exposed the route `get '/__next_race' => 'next_race#show'` in `config/routes.rb`.

### Testing
- No automated tests were run for this change.
- The change is limited to a new controller and a route and does not modify existing models or rake logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ac46f6b808329a7efe0db28beb9ee)