### PR TITLE
Batch racer aggregates when saving races

### DIFF
--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -114,8 +114,22 @@ class RacesController < ApplicationController
     streak_racer_ids = Racer.where("current_streak > 0 OR longest_streak > 0").pluck(:id)
     racer_ids_to_update = (racer_ids + streak_racer_ids).uniq
 
+    race_counts = Result.where(racer_id: racer_ids_to_update).group(:racer_id).count
+    latest_bibs_by_racer = {}
+    Result.joins(:race)
+          .where(racer_id: racer_ids_to_update)
+          .order("results.racer_id ASC, races.date DESC")
+          .pluck("results.racer_id", "results.bib")
+          .each do |racer_id, bib|
+      latest_bibs_by_racer[racer_id] ||= bib
+    end
+
     Racer.where(id: racer_ids_to_update).find_each do |racer|
-      update_racer_info(racer)
+      racer.update_columns(
+        race_count: race_counts[racer.id] || 0,
+        fav_bib: latest_bibs_by_racer[racer.id]
+      )
+      update_streak_calendar(racer)
     end
 
     race.update(state: 'FINISHED')


### PR DESCRIPTION
### Motivation
- Reduce per-racer queries when saving a race to avoid N+1 behavior and improve performance.
- Precompute per-racer aggregates (race counts and latest bib) so updates can be applied in bulk.
- Keep streak/calendar updates intact while eliminating expensive per-racer aggregation queries.

### Description
- Compute `race_counts` with `Result.where(racer_id: ids).group(:racer_id).count` to get counts in a single query.
- Build `latest_bibs_by_racer` by joining `results` to `races`, ordering by `races.date DESC`, and plucking `(racer_id, bib)` to capture the most recent bib per racer.
- Replace calls to `update_racer_info(racer)` with `racer.update_columns(race_count: ..., fav_bib: ...)` followed by `update_streak_calendar(racer)` to apply batched aggregates.
- Change was made in `app/controllers/races_controller.rb` while preserving the race state update to `'FINISHED'` and the redirect.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d1f153de883298acee5bb17a0b446)