### PR TITLE
Have SaveRaceJob inherit from ActiveJob::Base and remove ApplicationJob

### DIFF
--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -110,30 +110,9 @@ class RacesController < ApplicationController
   # Save race
   def save_race
     race = Race.find(params[:id])
-    racer_ids = race.results.pluck(:racer_id)
-    streak_racer_ids = Racer.where("current_streak > 0 OR longest_streak > 0").pluck(:id)
-    racer_ids_to_update = (racer_ids + streak_racer_ids).uniq
-
-    race_counts = Result.where(racer_id: racer_ids_to_update).group(:racer_id).count
-    latest_bibs_by_racer = {}
-    Result.joins(:race)
-          .where(racer_id: racer_ids_to_update)
-          .order("results.racer_id ASC, races.date DESC")
-          .pluck("results.racer_id", "results.bib")
-          .each do |racer_id, bib|
-      latest_bibs_by_racer[racer_id] ||= bib
-    end
-
-    Racer.where(id: racer_ids_to_update).find_each do |racer|
-      racer.update_columns(
-        race_count: race_counts[racer.id] || 0,
-        fav_bib: latest_bibs_by_racer[racer.id]
-      )
-      update_streak_calendar(racer)
-    end
-
     race.update(state: 'FINISHED')
-    redirect_to race
+    SaveRaceJob.perform_later(race.id)
+    redirect_to race, notice: "Race save is running in the background."
   end
 
   # enable race.

--- a/app/jobs/save_race_job.rb
+++ b/app/jobs/save_race_job.rb
@@ -1,0 +1,29 @@
+class SaveRaceJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(race_id)
+    race = Race.find(race_id)
+    racer_ids = race.results.pluck(:racer_id)
+    streak_racer_ids = Racer.where("current_streak > 0 OR longest_streak > 0").pluck(:id)
+    racer_ids_to_update = (racer_ids + streak_racer_ids).uniq
+
+    race_counts = Result.where(racer_id: racer_ids_to_update).group(:racer_id).count
+    latest_bibs_by_racer = {}
+    Result.joins(:race)
+          .where(racer_id: racer_ids_to_update)
+          .order("results.racer_id ASC, races.date DESC")
+          .pluck("results.racer_id", "results.bib")
+          .each do |racer_id, bib|
+      latest_bibs_by_racer[racer_id] ||= bib
+    end
+
+    Racer.where(id: racer_ids_to_update).find_each do |racer|
+      racer.update_columns(
+        race_count: race_counts[racer.id] || 0,
+        fav_bib: latest_bibs_by_racer[racer.id]
+      )
+      update_streak_calendar(racer)
+    end
+
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,5 +5,6 @@ Bundler.require(*Rails.groups)
 module Blog
   class Application < Rails::Application
     config.load_defaults 6.1
+    config.active_job.queue_adapter = :async
   end
 end


### PR DESCRIPTION
### Motivation
- Fix a production eager-load failure caused by relying on a missing `ApplicationJob` base class. 
- Ensure race-saving work runs asynchronously so controller requests do not block. 
- Keep the UI responsive by setting race `state` to `FINISHED` immediately before background processing. 
- Provide a simple in-process job backend for background execution.

### Description
- Deleted the unused `app/jobs/application_job.rb` base class and updated `SaveRaceJob` to inherit from `ActiveJob::Base` in `app/jobs/save_race_job.rb`.
- Enqueued background work with `SaveRaceJob.perform_later(race.id)` and set the race `state` to `FINISHED` before redirecting in `RacesController#save_race`.
- Added `config.active_job.queue_adapter = :async` to `config/application.rb` to enable an in-process job adapter for simple background execution.
- `SaveRaceJob` computes `race_count`, `fav_bib`, and updates streak calendars for affected `Racer` records in the background.

### Testing
- No automated tests were run for these changes.
- Manual verification steps were not recorded as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da255ae9c8329b16f5becd2297ec8)